### PR TITLE
integer overflow

### DIFF
--- a/crccheck/crc.py
+++ b/crccheck/crc.py
@@ -74,7 +74,7 @@ class CrcBase(CrccheckBase):
         """
         crc = self._value
         highbit = 1 << (self._width - 1)
-        mask = ((highbit - 1) << 1) | 0x1  # done this way to avoid overrun for 64-bit values
+        mask = (1 << self._width) - 1
         poly = self._poly
         shift = self._width - 8
         diff8 = -shift


### PR DESCRIPTION
integer overflow here not a concern for 2 reasons

a) python integers are arbitrary size, so don't overflow anyway

b) it still works in c/c++ because 1 << 64 overflows to 0, and 0 - 1 == 0xffffffffffffffff in both signed (twos complement) integers and unsigned integers.